### PR TITLE
Adjust code as needed for Spack builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ cet_cmake_env()
 cet_set_compiler_flags(DIAGS CAUTIOUS WERROR
                        NO_UNDEFINED
                        EXTRA_FLAGS -pedantic
-                                   -Wno-unused-local-typedefs -Wno-variadic-macros>)
+                                   -Wno-unused-local-typedefs -Wno-variadic-macros)
 cet_report_compiler_flags(REPORT_THRESHOLD VERBOSE)
 
 find_package(art REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,32 +20,27 @@ project(nuevdb VERSION 1.09.01 LANGUAGES CXX)
 include(CetCMakeEnv)
 cet_cmake_env()
 
-# -D_GLIBCXX_USE_NANOSLEEP is needed to make std::this_thread::sleep_for available. (IFDatabase)
 cet_set_compiler_flags(DIAGS CAUTIOUS WERROR
                        NO_UNDEFINED
-                       EXTRA_FLAGS -pedantic 
-                                   $<$<COMPILE_LANGUAGE:CXX>:-D_GLIBCXX_USE_NANOSLEEP 
+                       EXTRA_FLAGS -pedantic
                                    -Wno-unused-local-typedefs -Wno-variadic-macros>)
 cet_report_compiler_flags(REPORT_THRESHOLD VERBOSE)
 
 find_package(art REQUIRED)
-find_package(art_root_io REQUIRED PUBLIC)
+find_package(art_root_io REQUIRED)
 find_package(canvas_root_io REQUIRED)
 find_package(nusimdata REQUIRED)
 find_package(cetlib REQUIRED)
 find_package(cetlib_except REQUIRED)
-find_package(Boost COMPONENTS date_time filesystem thread regex REQUIRED)
+find_package(Boost COMPONENTS date_time REQUIRED)
 
 # macros
 include(ArtMake)
 include(BuildPlugins)
 include(CetRootCint)
 
-# include search path
-include_directories ( $ENV{CRYHOME}/src ) ### MIGRATE-ACTION-RECOMMENDED: use target_link_directories() with target semantics
-
 # source
-add_subdirectory (nuevdb)
+add_subdirectory(nuevdb)
 
 # ups - table and config files
 

--- a/nuevdb/CMakeLists.txt
+++ b/nuevdb/CMakeLists.txt
@@ -1,4 +1,2 @@
-
-add_subdirectory (EventDisplayBase)
-add_subdirectory (IFDatabase)
-
+add_subdirectory(EventDisplayBase)
+add_subdirectory(IFDatabase)

--- a/nuevdb/EventDisplayBase/CMakeLists.txt
+++ b/nuevdb/EventDisplayBase/CMakeLists.txt
@@ -1,6 +1,4 @@
-
-find_package(ROOT COMPONENTS Tree Gui REQUIRED PUBLIC)
-##find_package(ROOT COMPONENTS Eve EG GX11 TreePlayer Geom Ged RGL Core RIO Net Hist Graf Graf3d Gpad Rint Postscript Matrix Physics MathCore Thread REQUIRED)
+find_package(ROOT COMPONENTS Tree Gui REQUIRED EXPORT)
 find_package(ROOT COMPONENTS Core Graf Graf3d Rint REQUIRED)
 
 FILE( GLOB src_files *.cxx )
@@ -19,28 +17,10 @@ art_make_library( SOURCE ${src_files} ${CMAKE_CURRENT_BINARY_DIR}/EventDisplayBa
               art::Framework_Principal
               art::Persistency_Provenance
               art::Utilities
-              ##canvas::canvas
               messagefacility::MF_MessageLogger
               fhiclcpp::fhiclcpp
               cetlib::cetlib
               cetlib_except::cetlib_except
-              #ROOT::Eve
-              #ROOT::EG
-              #ROOT::GX11
-              #ROOT::TreePlayer
-              #ROOT::Geom
-              #ROOT::Ged
-              #ROOT::RGL
-              #ROOT::RIO
-              #ROOT::Net
-              #ROOT::Hist
-              #ROOT::Gpad
-              #ROOT::Tree
-              #ROOT::Postscript
-              #ROOT::Matrix
-              #ROOT::Physics
-              #ROOT::MathCore
-              #ROOT::Thread 
               ROOT::Graf
               ROOT::Graf3d
               ROOT::Gui

--- a/nuevdb/IFDatabase/CMakeLists.txt
+++ b/nuevdb/IFDatabase/CMakeLists.txt
@@ -1,38 +1,26 @@
-
-find_package(libwda REQUIRED PUBLIC)
+find_package(libwda REQUIRED)
 find_package(PostgreSQL REQUIRED)
-### MIGRATE-ACTION-RECOMMENDED we are using UPS variables here because find_package returns a path
-find_library( PQ NAMES pq PATHS ENV POSTGRESQL_LIBRARIES NO_DEFAULT_PATH )
-find_library( CURL NAMES curl )
 
-art_make_library( SOURCE Column.cpp  ColumnDef.cpp  Row.cpp  Table.cpp  Util.cpp
-                     #${CMAKE_CURRENT_BINARY_DIR}/IFDatabaseCint.cc
-                  LIBRARIES PRIVATE
-                                Boost::date_time
-                                Boost::filesystem
-                                Boost::thread
-                                Boost::regex
-                                PQ
-                                ${CURL}
+art_make_library(SOURCE Column.cpp  ColumnDef.cpp  Row.cpp  Table.cpp  Util.cpp
+                 LIBRARIES PRIVATE
+                        Boost::date_time
+                        PostgreSQL::PostgreSQL
                  PUBLIC wda::wda
                  )
 
 cet_make_exec( NAME tagConditionsTableInDB
                SOURCE tagConditionsTableInDB.cc
                LIBRARIES PRIVATE nuevdb::IFDatabase
-                         ${CURL}
                )
 
 cet_make_exec( NAME writeConditionsCSVToDB.cc
                SOURCE writeConditionsCSVToDB.cc
                LIBRARIES PRIVATE nuevdb::IFDatabase
-                         ${CURL}
                )
 
 cet_make_exec( NAME dumpConditionsToCSV
                SOURCE dumpConditionsToCSV.cc
                LIBRARIES PRIVATE nuevdb::IFDatabase
-                         ${CURL}
                )
 
 cet_build_plugin( DBI art::service

--- a/nuevdb/IFDatabase/Column.h
+++ b/nuevdb/IFDatabase/Column.h
@@ -107,7 +107,7 @@ namespace nutools {
 		tstr == "y" || tstr == "yes" || tstr == "1" || tstr == "on") 
 	      fValue[0] = '1';
 	    else 
-	      fValue[1] = '0';
+              fValue[0] = '0';
 	    return true;
 	  }
 	  else {

--- a/nuevdb/IFDatabase/Table.cpp
+++ b/nuevdb/IFDatabase/Table.cpp
@@ -8,12 +8,9 @@
 #include <ctime>
 #include <cinttypes>
 #include <cstdio>
-//#include <sys/types.h>
-//#include <sys/sysinfo.h>
 
 #include <libpq-fe.h>
 
-//#include <boost/tokenizer.hpp>
 #include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/case_conv.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>


### PR DESCRIPTION
Removes unnecessary dependencies and simplifies CMakeLists.txt

**N.B.** These changes should also work for UPS builds.